### PR TITLE
Add support for MIDI Velocity Curves

### DIFF
--- a/js/parameters.js
+++ b/js/parameters.js
@@ -147,4 +147,5 @@ let params = [
             'allow repeating notes (true random)'], 1)),
     new Param(73, 'ARP/SEQ CV OUT Mirrors KB CV', Options(['Off', 'On'], 0)),
     new Param(74, 'KB CV OUT Mirrors ARP/SEQ CV', Options(['Off', 'On'], 0)),
+    new Param(75, 'MIDI Velocity Curves', Options(['Base', 'Linear', 'Stretched', 'Compressed'], 0)),
 ];


### PR DESCRIPTION
Add support for MIDI Velocity Curves added in firmware 1.3.0

https://api.moogmusic.com/sites/default/files/2023-03/Matriarch_V1.3.0_Firmware_Update_120522.pdf

<img width="930" alt="Screenshot 2023-03-15 at 23 33 29" src="https://user-images.githubusercontent.com/419996/225310057-84e87211-c81b-4deb-bca7-eaf0a12e03d6.png">
